### PR TITLE
Unmarshaling objects: ALLOCATE + INTIALIZE

### DIFF
--- a/unmarshal.lisp
+++ b/unmarshal.lisp
@@ -23,7 +23,7 @@
 (defmethod initialize-unmarshalled-instance (object)
    "Called as the last step of the deserialization of an object. 
 !Must return the object!!"
-   object)
+   (initialize-instance object))
 
 
 ;;; =============================================================
@@ -83,7 +83,7 @@
 ;;;  07.07.98 cjo: LOOP
 (defmethod unmarshal-fn ((version (eql (coding-idiom :coding-release-no))) 
                       (type (eql (coding-idiom :object))) token &optional (circle-hash NIL))
-   (let* ((out (make-instance (third token)))
+   (let* ((out (allocate-instance (find-class (third token))))
           (slots (class-persistant-slots out))
           (values (cdddr token)))
 


### PR DESCRIPTION
Consider this class:

```
(defclass bad ()
  ((mandatory
      :initform (error "Argument must be provided")
      :initarg :mandatory)
   (something :initform (random))))
```

Assume also that MANDATORY is a persistent slot and SOMETHING isn't:

```
(defmethod marshal:class-persistant-slots ((o bad))
  '(mandatory))
```

UNMARHSAL signals an error because it uses MAKE-INSTANCE. We need to use
ALLOCATE-INSTANCE instead. However, in that case SOMETHING would not get
properly initialized. That's why the commit also changes the default
method of INITIALIZE-UNMARSHALLED-INSTANCE, so that the object's slots
which are not set by UNMARSHAL can take default values.
